### PR TITLE
Update AutoDLL Webpack Plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "webpack-flush-chunks": "^1.1.22"
   },
   "devDependencies": {
-    "autodll-webpack-plugin": "^0.3.2",
+    "autodll-webpack-plugin": "^0.3.4",
     "babel-cli": "^6.24.0",
     "babel-core": "^6.24.0",
     "babel-eslint": "^8.0.1",


### PR DESCRIPTION
AutoDLL had an issue which impacted builds on windows machines, updating to 0.3.4 fixes the problem.